### PR TITLE
Update ovos-bus-client dependency and unit test automation

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           pytest tests/test_request_validation.py --doctest-modules --junitxml=tests/request-validation-test-results.xml
       - name: Upload request validation test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: request-validation-test-results
+          name: request-validation-test-results-${{ matrix.python-version }}
           path: tests/request-validation-test-results.xml

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,4 +2,4 @@ neon-utils[network]~=1.0
 pydantic~=1.9
 neon-mq-connector~=0.6
 ovos-config~=0.0,>=0.0.3
-ovos-bus-client~=0.0.4
+ovos-bus-client~=0.0,>=0.0.4


### PR DESCRIPTION
# Description
Allow resolution of ovos-bus-client 0.1+
Update deprecated shared action in unit test automation Related to https://github.com/NeonGeckoCom/NeonCore/pull/708

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->