### PR TITLE
Refactor Klat API

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/requirements.txt
-          pip install -r requirements/dev_requirements.txt
-
+          pip install .[test]
       - name: Test Request Validation
         run: |
           pytest tests/test_request_validation.py --doctest-modules --junitxml=tests/request-validation-test-results.xml

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -147,6 +147,9 @@ class ChatAPIProxy(MQConnector):
                     LOG.info(f"message={message}")
                     LOG.error(f"Failed to parse response message: {e}")
                 return
+            except TypeError as e:
+                LOG.error(f"Failed to parse message: {message.serialize()}")
+                LOG.exception(e)
 
         LOG.debug(f'Processed neon response: {message.msg_type} in '
                   f'{_stopwatch.time}s')

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -207,6 +207,10 @@ class ChatAPIProxy(MQConnector):
             f'data={dict_data["data"].keys()}|'
             f'context={dict_data["context"].keys()}')
         try:
+            # TODO: Klat context is currently required for audio responses. In
+            # the future, these should be handled for any response with `MQ`
+            # context.
+            dict_data['context'].setdefault('klat_data', {"cid": "", "sid": ""})
             neon_api_message = NeonApiMessage(**dict_data)
         except ValidationError as e:
             LOG.error(e)

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -159,11 +159,10 @@ class ChatAPIProxy(MQConnector):
             body['context']['timing']['mq_from_core'] = response_handled - \
                 body['context']['timing']['response_sent']
         body['context']['timing']['mq_response_handler'] = _stopwatch.time
-        routing_key = message.context.get("mq",
-                                          {}).get("routing_key",
-                                                  'neon_chat_api_response')
-
-        # This takes on the order of ~=0.04s
+        routing_key = message.context.get("mq", {}).get("routing_key") or \
+            'neon_chat_api_response'
+        LOG.debug(f"Sending message ({message.msg_type}) with "
+                  f"routing_key={routing_key}")
         self.send_message(request_data=body, queue=routing_key)
         LOG.debug(f"Sent message with routing_key={routing_key}")
 

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -143,8 +143,9 @@ class ChatAPIProxy(MQConnector):
                 response_message.routing_key = response_message.routing_key or \
                     "neon_chat_api_response"
             except ValidationError as e:
-                LOG.info(f"message={message}")
-                LOG.error(f"Failed to parse response message: {e}")
+                if message.context.get("mq"):
+                    LOG.info(f"message={message}")
+                    LOG.error(f"Failed to parse response message: {e}")
                 return
 
         LOG.debug(f'Processed neon response: {message.msg_type} in '

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -134,8 +134,8 @@ class ChatAPIProxy(MQConnector):
         :param message: Received Message object
         """
         response_handled = time.time()
-
-        with Stopwatch() as _stopwatch:
+        _stopwatch = Stopwatch()
+        with _stopwatch:
             try:
                 response_message = NeonApiMessage(msg_type=message.msg_type,
                                                   data=message.data,

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -137,7 +137,9 @@ class ChatAPIProxy(MQConnector):
 
         with Stopwatch() as _stopwatch:
             try:
-                response_message = NeonApiMessage(**message.as_dict)
+                response_message = NeonApiMessage(msg_type=message.msg_type,
+                                                  data=message.data,
+                                                  context=message.context)
             except ValidationError as e:
                 LOG.info(f"message={message}")
                 LOG.error(f"Failed to parse response message: {e}")

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -256,7 +256,7 @@ class ChatAPIProxy(MQConnector):
 
         _stopwatch.stop()
         neon_api_message.context.timing.mq_input_handler = _stopwatch.time
-        message = neon_api_message.as_message()
+        message = neon_api_message.as_messagebus_message()
         if message.context.get('ident') and \
                 message.msg_type in ("neon.get_stt", "neon.get_tts",
                                         "neon.audio_input"):

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -135,7 +135,7 @@ class ChatAPIProxy(MQConnector):
         """
         response_handled = time.time()
 
-        with _stopwatch := Stopwatch():
+        with Stopwatch() as _stopwatch:
             try:
                 response_message = NeonApiMessage(message.as_dict())
             except ValidationError as e:

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -150,6 +150,7 @@ class ChatAPIProxy(MQConnector):
             except TypeError as e:
                 LOG.error(f"Failed to parse message: {message.serialize()}")
                 LOG.exception(e)
+                return
 
         LOG.debug(f'Processed neon response: {message.msg_type} in '
                   f'{_stopwatch.time}s')
@@ -231,11 +232,10 @@ class ChatAPIProxy(MQConnector):
         dict_data = b64_to_dict(body)
         LOG.info(f'Received user message: {dict_data.get("msg_type")}|'
             f'data={dict_data["data"].keys()}|'
-            f'context={dict_data["context"].keys()}')
+            f'context={dict_data["context"].keys()}|{dict_data.keys()}')
         try:
-            # TODO: Klat context is currently required for audio responses. In
-            # the future, these should be handled for any response with `MQ`
-            # context.
+            # TODO: Klat context was previously required for audio responses.
+            # These are now handled for any response with `MQ` context.
             dict_data['context'].setdefault('klat_data', {"cid": "", "sid": ""})
             neon_api_message = NeonApiMessage(**dict_data)
         except ValidationError as e:

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -137,8 +137,9 @@ class ChatAPIProxy(MQConnector):
 
         with Stopwatch() as _stopwatch:
             try:
-                response_message = NeonApiMessage(message.as_dict())
+                response_message = NeonApiMessage(**message.as_dict())
             except ValidationError as e:
+                LOG.info(f"message={message}")
                 LOG.error(f"Failed to parse response message: {e}")
                 return
 

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -205,7 +205,7 @@ class ChatAPIProxy(MQConnector):
             f'data={dict_data["data"].keys()}|'
             f'context={dict_data["context"].keys()}')
         try:
-            neon_api_message = NeonApiMessage(**body)
+            neon_api_message = NeonApiMessage(**dict_data)
         except ValidationError as e:
             LOG.error(e)
             # This Message is malformed

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -39,6 +39,7 @@ from ovos_config.config import Configuration
 from neon_mq_connector.connector import MQConnector, ConsumerThreadInstance
 from pydantic import ValidationError
 from neon_data_models.models.api.mq.neon import NeonApiMessage
+from neon_data_models.models.base.contexts import MQContext
 from neon_messagebus_mq_connector.enums import NeonResponseTypes
 
 
@@ -238,6 +239,10 @@ class ChatAPIProxy(MQConnector):
             # These are now handled for any response with `MQ` context.
             dict_data['context'].setdefault('klat_data', {"cid": "", "sid": ""})
             neon_api_message = NeonApiMessage(**dict_data)
+            if not neon_api_message.context.mq:
+                # backwards-compat parsing
+                neon_api_message.context.mq = MQContext(**dict_data)
+
         except ValidationError as e:
             LOG.error(e)
             # This Message is malformed

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -137,7 +137,7 @@ class ChatAPIProxy(MQConnector):
 
         with Stopwatch() as _stopwatch:
             try:
-                response_message = NeonApiMessage(**message.as_dict())
+                response_message = NeonApiMessage(**message.as_dict)
             except ValidationError as e:
                 LOG.info(f"message={message}")
                 LOG.error(f"Failed to parse response message: {e}")

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -140,6 +140,8 @@ class ChatAPIProxy(MQConnector):
                 response_message = NeonApiMessage(msg_type=message.msg_type,
                                                   data=message.data,
                                                   context=message.context)
+                response_message.routing_key = response_message.routing_key or \
+                    "neon_chat_api_response"
             except ValidationError as e:
                 LOG.info(f"message={message}")
                 LOG.error(f"Failed to parse response message: {e}")

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -222,7 +222,7 @@ class ChatAPIProxy(MQConnector):
         # Add timing metrics
         if neon_api_message.context.timing.client_sent:
             neon_api_message.context.timing.mq_from_client = \
-                input_received - neon_api_message.context.timing.client_sent
+                input_received - neon_api_message.context.timing.client_sent.timestamp()
 
         _stopwatch.stop()
         neon_api_message.context.timing.mq_input_handler = _stopwatch.time

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -214,6 +214,7 @@ class ChatAPIProxy(MQConnector):
             response = Message("klat.error", {"error": repr(e),
                                               "data": dict_data},
                                context)
+            response.context.setdefault("klat_data", {})
             response.context['klat_data'].setdefault('routing_key',
                                                      'neon_chat_api_error')
             self.handle_neon_message(response)

--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -233,7 +233,7 @@ class ChatAPIProxy(MQConnector):
         dict_data = b64_to_dict(body)
         LOG.info(f'Received user message: {dict_data.get("msg_type")}|'
             f'data={dict_data["data"].keys()}|'
-            f'context={dict_data["context"].keys()}|{dict_data.keys()}')
+            f'context={dict_data["context"].keys()}')
         try:
             # TODO: Klat context was previously required for audio responses.
             # These are now handled for any response with `MQ` context.
@@ -241,6 +241,9 @@ class ChatAPIProxy(MQConnector):
             neon_api_message = NeonApiMessage(**dict_data)
             if not neon_api_message.context.mq:
                 # backwards-compat parsing
+                LOG.warning(f"Handling legacy message from "
+                            f"client={neon_api_message.context.client}. Please "
+                            f"update to include `mq` context")
                 neon_api_message.context.mq = MQContext(**dict_data)
 
         except ValidationError as e:

--- a/neon_messagebus_mq_connector/messages.py
+++ b/neon_messagebus_mq_connector/messages.py
@@ -28,7 +28,8 @@
 
 
 from ovos_utils.log import log_deprecation
-from neon_data_models.models.messagebus import BaseMessage as MessageModel, \
+from neon_data_models.models.base.messagebus import \
+    BaseMessage as MessageModel, \
     NeonTextInput as RecognizerMessage, NeonGetStt as STTMessage, \
     NeonGetTts as TTSMessage, NeonAudioInput as AudioInput
 

--- a/neon_messagebus_mq_connector/messages.py
+++ b/neon_messagebus_mq_connector/messages.py
@@ -27,87 +27,14 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from typing import List
-from pydantic import BaseModel as PydanticBaseModel, create_model
+from ovos_utils.log import log_deprecation
+from neon_data_models.models.messagebus import BaseMessage as MessageModel, \
+    NeonTextInput as RecognizerMessage, NeonGetStt as STTMessage, \
+    NeonGetTts as TTSMessage, NeonAudioInput as AudioInput
 
 
-class BaseModel(PydanticBaseModel):
-    class Config:
-        extra = "allow"
-
-
-class MessageModel(BaseModel):
-    msg_type: str
-    data: dict
-    context: dict
-
-
-class RecognizerMessage(BaseModel):
-    msg_type: str = "recognizer_loop:utterance"
-    data: create_model("Data",
-                       utterances=(list, ...),
-                       lang=(str, ...),
-                       __base__=BaseModel,
-                       )
-    context: create_model("Context",
-                          client_name=(str, "pyklatchat"),
-                          client=(str, "browser"),
-                          source=(str, "mq_api"),
-                          destination=(list, ["skills"]),
-                          timing=(dict, {}),
-                          neon_should_respond=(bool, True),
-                          username=(str, "guest"),
-                          klat_data=(dict, {}),
-                          mq=(dict, None),
-                          user_profiles=(list, []),
-                          request_skills=(List[str], None),
-                          __base__=BaseModel,
-                          )
-
-
-class AudioInput(BaseModel):
-    msg_type: str = "neon.audio_input"
-    data: create_model("Data",
-                       audio_data=(str, ...),
-                       lang=(str, ...),
-                       __base__=BaseModel,
-                       )
-    context: create_model("Context",
-                          source=(str, "mq_api"),
-                          destination=(list, ["speech"]),
-                          username=(str, "guest"),
-                          user_profiles=(list, []),
-                          __base__=BaseModel,
-                          )
-
-
-class STTMessage(BaseModel):
-    msg_type: str = "neon.get_stt"
-    data: create_model("Data",
-                       audio_data=(str, ...),
-                       lang=(str, ...),
-                       __base__=BaseModel,
-                       )
-    context: create_model("Context",
-                          source=(str, "mq_api"),
-                          destination=(list, ["speech"]),
-                          __base__=BaseModel,
-                          )
-
-
-class TTSMessage(BaseModel):
-    msg_type: str = "neon.get_tts"
-    data: create_model("Data",
-                       text=(str, ...),
-                       lang=(str, ...),
-                       __base__=BaseModel,
-                       )
-    context: create_model("Context",
-                          source=(str, "mq_api"),
-                          destination=(list, ["audio"]),
-                          __base__=BaseModel,
-                          )
-
+log_deprecation("Import from `neon_data_models.models.messagebus` directly",
+                "2.0.0")
 
 templates = {
     "stt": STTMessage,

--- a/neon_messagebus_mq_connector/messages.py
+++ b/neon_messagebus_mq_connector/messages.py
@@ -29,7 +29,8 @@
 
 from ovos_utils.log import log_deprecation
 from neon_data_models.models.base.messagebus import \
-    BaseMessage as MessageModel, \
+    BaseMessage as MessageModel
+from neon_data_models.models.api.messagebus import \
     NeonTextInput as RecognizerMessage, NeonGetStt as STTMessage, \
     NeonGetTts as TTSMessage, NeonAudioInput as AudioInput
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,4 +2,4 @@ neon-utils[network]~=1.0
 neon-mq-connector~=0.6
 ovos-config~=0.0,>=0.0.3
 ovos-bus-client~=0.0,>=0.0.4
-neon-data-models~=0.0,>=0.0.2a1
+neon-data-models~=0.0,>=0.0.2a3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 neon-utils[network]~=1.0
-pydantic>=1.9,<3.0
 neon-mq-connector~=0.6
 ovos-config~=0.0,>=0.0.3
 ovos-bus-client~=0.0,>=0.0.4
+neon-data-models@git+https://github.com/NeonGeckoCom/neon-data-models@FEAT_KlatNeonApi

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,4 +2,4 @@ neon-utils[network]~=1.0
 neon-mq-connector~=0.6
 ovos-config~=0.0,>=0.0.3
 ovos-bus-client~=0.0,>=0.0.4
-neon-data-models@git+https://github.com/NeonGeckoCom/neon-data-models@FEAT_KlatNeonApi
+neon-data-models~=0.0,>=0.0.2a1

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ setuptools.setup(
     author_email='developers@neon.ai',
     license='BSD-3-Clause',
     description="MQ-Messagebus Connector Module",
+    extras_require={
+        "test": get_requirements("dev_requirements.txt")
+    },
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/neongeckocom/neon-messagebus-mq-connector",

--- a/tests/test_request_validation.py
+++ b/tests/test_request_validation.py
@@ -31,11 +31,7 @@ import unittest
 from copy import deepcopy
 from pydantic import ValidationError
 
-import os
-import sys
-sys.path.append(os.path.abspath(os.path.dirname(os.path.realpath(__file__))+"/../neon_messagebus_mq_connector"))
-
-from messages import STTMessage, TTSMessage
+from neon_messagebus_mq_connector.messages import STTMessage, TTSMessage
 
 
 class RequestTests(unittest.TestCase):
@@ -65,7 +61,8 @@ class RequestTests(unittest.TestCase):
             timing={"1": "1"},
             neon_should_respond=False,
             username="1",
-            klat_data={"1": "1"},
+            klat_data={"sid": "1",
+                       "cid": "1"},
             user_profiles=[{"1": "1"}]
         )
     )


### PR DESCRIPTION
# Description
Override error handler to include a stack trace for uncaught exceptions
Remove Klat-specific response formatting
Remove unused `request_skills` context

# Issues
- Closes #60 
- Needs https://github.com/NeonGeckoCom/neon-data-models/pull/18
- Related to https://github.com/NeonGeckoCom/pyklatchat/milestone/2

# Other Notes
Deployed to neon_messagebus alpha namespace