### PR TITLE
feat: forward node.invoke_native to MQ

### DIFF
--- a/neon_messagebus_mq_connector/controller.py
+++ b/neon_messagebus_mq_connector/controller.py
@@ -97,6 +97,7 @@ class ChatAPIProxy(MQConnector):
         self._bus.on('neon.languages.get.response', self.handle_neon_message)
         self._bus.on('neon.alert_expired', self.handle_neon_message)
         self._bus.on('neon.skill_api.get.response', self.handle_neon_message)
+        self._bus.on('node.invoke_native', self.handle_neon_message)
 
     def connect_bus(self, refresh: bool = False):
         """

--- a/tests/test_request_validation.py
+++ b/tests/test_request_validation.py
@@ -31,6 +31,7 @@ import unittest
 from copy import deepcopy
 from pydantic import ValidationError
 
+from neon_data_models.models.api.mq.neon import NeonApiMessage
 from neon_messagebus_mq_connector.messages import STTMessage, TTSMessage
 
 
@@ -109,3 +110,41 @@ class RequestTests(unittest.TestCase):
 
         # self.assertEqual(dict_keys["context"]["neon_should_respond"], True)
         self.assertEqual(dict_keys["context"]["destination"], ['audio'])
+
+
+class NodeInvokeNativeTests(unittest.TestCase):
+    """`node.invoke_native` is forwarded by the generic handle_neon_message,
+    so it has no message class of its own -- these pin the two properties
+    that forwarding depends on."""
+
+    default_invoke = dict(
+        msg_type="node.invoke_native",
+        data=dict(action="launch_camera_app"),
+        context=dict(
+            mq={"routing_key": "node_a1b2c3d4"},
+            session={"session_id": "node-a1b2c3d4"},
+        ),
+    )
+
+    def test_invoke_native_validates(self):
+        message = NeonApiMessage(**deepcopy(self.default_invoke))
+        self.assertEqual(message.msg_type, "node.invoke_native")
+        self.assertEqual(message.data["action"], "launch_camera_app")
+
+    def test_routing_key_is_read_from_context(self):
+        """The Node is unicast by routing_key. If this fell back to the
+        shared neon_chat_api_response queue, one Node's camera intent
+        would be delivered to every connected client."""
+        message = NeonApiMessage(**deepcopy(self.default_invoke))
+        self.assertEqual(message.routing_key, "node_a1b2c3d4")
+
+    def test_params_payload_survives(self):
+        """`params` is an open object per PLATFORM_NATIVE_ACTIONS.md, so
+        the messaging actions' pre-fill must pass through untouched."""
+        keys = deepcopy(self.default_invoke)
+        keys["data"] = dict(
+            action="launch_email_app",
+            params=dict(subject="Running late", body="Be there soon"),
+        )
+        message = NeonApiMessage(**keys)
+        self.assertEqual(message.data["params"]["subject"], "Running late")


### PR DESCRIPTION
## Problem

`register_bus_handlers` is an explicit whitelist and does not include `node.invoke_native`. A skill emitting it has the message **silently dropped** — it never reaches HANA, so it never reaches the Node.

The failure mode is unpleasant to debug: the skill waits out its full response timeout (5–10s per `PLATFORM_NATIVE_ACTIONS.md`) and there is no error anywhere in the logs explaining why. Nothing appears to be broken; the message simply doesn't exist as far as the connector is concerned.

This gates the skill-side half of the Neon Node platform-native actions work (CO4) — `skill-launcher`'s `if node:` branch can't reach a Node until this lands, no matter how correct the skill is.

## Fix

One line, alongside the other forwarded types:

```python
self._bus.on('node.invoke_native', self.handle_neon_message)
```

`handle_neon_message` is already generic — it wraps `msg_type`/`data`/`context` into a `NeonApiMessage` and publishes to `context.mq.routing_key`. That's the same path `klat.response` uses to reach HANA today, so no special handling is needed.

## Tests

Three tests in the existing pydantic style, covering the two properties forwarding actually depends on:

- the `node.invoke_native` envelope validates as a `NeonApiMessage`
- `routing_key` is read from `context.mq` rather than falling back to the shared `neon_chat_api_response` queue — that fallback would deliver one Node's camera intent to **every** connected client
- `data.params` (the open payload object for the SMS/email pre-fill actions) passes through untouched

8 passed locally (3 new + 5 existing).

Not covered: that the handler is actually registered. `ChatAPIProxy.__init__` calls `connect_bus()` and registers MQ consumers, so asserting registration would need a mocked bus with no precedent in this repo. Flagging it rather than inventing a harness — happy to add one if you'd prefer.

## Prior validation

Verified against a live hub on 2026-07-18: publishing `node.invoke_native` directly to hana's MQ queue — simulating exactly this fix — delivered it over WS to a Node client, and `node.invoke_native.response` came back on the bus. This change closes the gap that simulation was standing in for.

## Related

- `NeonGeckoCom/neon-data-models#35` (merged) — the `NodeInvokeNative` models
- Spec: `PLATFORM_NATIVE_ACTIONS.md` v0.3, approved in `neon-node-design#3`